### PR TITLE
Add home page content

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -170,3 +170,50 @@ body {
     padding-top: 20px;
     font-size: 0.8rem;
 }
+
+/* Home page styles */
+.hero {
+    background-color: #f5f5f5;
+    text-align: center;
+    padding: 60px 20px;
+}
+
+.hero h1 {
+    margin: 0;
+    color: #28a745;
+}
+
+.hero p {
+    max-width: 800px;
+    margin: 20px auto;
+    font-size: 1.1rem;
+}
+
+.section {
+    max-width: 1000px;
+    margin: 40px auto;
+    padding: 0 20px;
+}
+
+.section h2 {
+    color: #28a745;
+}
+
+.section ul {
+    list-style: none;
+    padding-left: 0;
+}
+
+.section ul li {
+    margin-bottom: 10px;
+}
+
+.cta-links a {
+    color: #28a745;
+    text-decoration: none;
+    margin: 0 5px;
+}
+
+.cta-links a:hover {
+    text-decoration: underline;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Anvizor Solutions</title>
+    <title>Home | Anvizor Solutions</title>
     <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
@@ -56,7 +56,48 @@
         </nav>
     </header>
     <main>
-        <h1>Welcome to Anvizor</h1>
+        <section class="hero">
+            <h1>Engineering Tomorrow’s Solutions — Today.</h1>
+            <p class="subheading">From AI-driven healthcare diagnostics to enterprise-grade ERP, from smart logistics to social tech — Anvizor Solutions delivers innovation at scale.</p>
+            <p class="intro-banner">We are a next-gen software engineering firm led by 15+ years of industry excellence. Our mission is simple: deliver transformative, intelligent, and scalable solutions by collaborating transparently with our clients and solving real-world challenges using future-ready technology.</p>
+        </section>
+
+        <section class="section core-domains">
+            <h2>Our Core Domains</h2>
+            <ul>
+                <li><strong>Artificial Intelligence &amp; ML</strong> — Custom AI agents, Generative AI, MLOps, and Cognitive Intelligence — we build AI that adapts, learns, and scales.</li>
+                <li><strong>Healthcare Technology</strong> — AI-based diagnostics, EHR/HL7 solutions, behavioral health tracking, and real-time clinical platforms.</li>
+                <li><strong>ERP &amp; Logistics</strong> — Smart order systems, iteration hubs, supply chain automation, petroleum logistics, and predictive tools.</li>
+                <li><strong>FinTech Solutions</strong> — Digital banking, payment systems, fraud detection, robo-advisory, and regulatory compliance platforms.</li>
+                <li><strong>Product Engineering</strong> — From MVP to full-scale rollout — with gold-standard SDLC, UAT, hypercare, and post-production evolution.</li>
+                <li><strong>Mobile &amp; Web Apps</strong> — Sensor-enabled, BLE-integrated, cloud-native apps for Android, iOS, and hybrid React Native environments.</li>
+                <li><strong>DevOps &amp; Cloud</strong> — Serverless deployments, CI/CD, infrastructure-as-code, and agile DevSecOps for speed and stability.</li>
+                <li><strong>UI/UX Design</strong> — Intuitive interfaces, modular dashboards, immersive wireframes, and accessible experiences.</li>
+                <li><strong>Social Tech</strong> — Cloud-based networks, event broadcasting, community building, and AI-driven social engagement.</li>
+            </ul>
+        </section>
+
+        <section class="section why-anvizor">
+            <h2>Why Anvizor?</h2>
+            <ul>
+                <li>15+ Years of Proven, Cross-Industry Experience</li>
+                <li>Enterprise-Level Solution Design &amp; Delivery</li>
+                <li>Transparent, Collaborative Engagement Models</li>
+                <li>Innovation-First, AI-Infused Engineering Culture</li>
+                <li>Deep Expertise Across AI, Cloud, DevOps, IoT, and Data Systems</li>
+                <li>Full Product Lifecycle Ownership — From Discovery to Scale</li>
+                <li>Gold-Standard Engineering: CI/CD, UAT, SDLC, Hypercare</li>
+                <li>Future-Ready Architectures Designed for Scalability &amp; Resilience</li>
+                <li>Global Reach with Strategic Delivery in the USA &amp; Europe</li>
+            </ul>
+            <p class="tagline">We Don’t Just Code. We Engineer Possibility.</p>
+        </section>
+
+        <section class="section cta">
+            <h2>Let’s Build the Future Together</h2>
+            <p>Whether you're a startup with a vision or an enterprise seeking transformation — Anvizor is your trusted tech ally.</p>
+            <p class="cta-links"><a href="/contact-us.html">Talk to Us</a> | <a href="/contact-us.html">Schedule a Discovery Call</a> | <a href="/what-we-think/case-studies.html">Explore Our Work</a></p>
+        </section>
     </main>
 <footer class="site-footer">
   <div class="footer-container">


### PR DESCRIPTION
## Summary
- extend home page with hero text, domain list and CTAs
- style new home page sections

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685176d578e08324bc999d6e2b5a2abe