### PR TITLE
Standardize AI pages

### DIFF
--- a/public/ai/ai-agent.html
+++ b/public/ai/ai-agent.html
@@ -58,33 +58,51 @@
         </nav>
     </header>
     <main>
-        <h1>Intelligent AI Agents That Think, Act, and Learn</h1>
-        <p>Anvizor develops AI agents that autonomously analyze information, take action, and improve through continuous learning. Our technology transforms how businesses operate by automating complex tasks and delivering real-time insights.</p>
-        <h2>What is an AI Agent?</h2>
-        <p>An AI agent is a software program capable of perceiving its environment, reasoning about data, and performing tasks with minimal human input. These agents use machine learning to adapt and get better over time.</p>
-        <h2>Capabilities of Our AI Agents</h2>
-        <ul>
-            <li>Natural language understanding</li>
-            <li>Decision making with predictive analytics</li>
-            <li>Process automation and workflow orchestration</li>
-            <li>Integration with existing business systems</li>
-        </ul>
-        <h2>Use Cases</h2>
-        <ul>
-            <li>Customer support chatbots</li>
-            <li>Automated financial analysis</li>
-            <li>Smart logistics and supply chain management</li>
-            <li>Personalized marketing recommendations</li>
-        </ul>
-        <h2>Why Choose Anvizor AI Agents?</h2>
-        <ul>
-            <li>Proven expertise in artificial intelligence</li>
-            <li>Custom solutions tailored to your industry</li>
-            <li>Scalable architecture for enterprise needs</li>
-            <li>Dedicated support and ongoing optimization</li>
-        </ul>
-        <section class="call-to-action">
-            <p><a href="/contact-us.html">Schedule a Call</a> or <a href="/contact-us.html">Request a Demo</a> to see what our AI agents can do.</p>
+        <section class="hero">
+            <h1>Intelligent AI Agents That Think, Act, and Learn</h1>
+        </section>
+
+        <section class="section intro">
+            <p>Anvizor develops AI agents that autonomously analyze information, take action, and improve through continuous learning. Our technology transforms how businesses operate by automating complex tasks and delivering real-time insights.</p>
+        </section>
+
+        <section class="section overview">
+            <h2>What is an AI Agent?</h2>
+            <p>An AI agent is a software program capable of perceiving its environment, reasoning about data, and performing tasks with minimal human input. These agents use machine learning to adapt and get better over time.</p>
+        </section>
+
+        <section class="section capabilities">
+            <h2>Capabilities of Our AI Agents</h2>
+            <ul>
+                <li>Natural language understanding</li>
+                <li>Decision making with predictive analytics</li>
+                <li>Process automation and workflow orchestration</li>
+                <li>Integration with existing business systems</li>
+            </ul>
+        </section>
+
+        <section class="section use-cases">
+            <h2>Use Cases</h2>
+            <ul>
+                <li>Customer support chatbots</li>
+                <li>Automated financial analysis</li>
+                <li>Smart logistics and supply chain management</li>
+                <li>Personalized marketing recommendations</li>
+            </ul>
+        </section>
+
+        <section class="section why-choose">
+            <h2>Why Choose Anvizor AI Agents?</h2>
+            <ul>
+                <li>Proven expertise in artificial intelligence</li>
+                <li>Custom solutions tailored to your industry</li>
+                <li>Scalable architecture for enterprise needs</li>
+                <li>Dedicated support and ongoing optimization</li>
+            </ul>
+        </section>
+
+        <section class="section cta">
+            <p class="cta-links"><a href="/contact-us.html">Schedule a Call</a> or <a href="/contact-us.html">Request a Demo</a></p>
         </section>
     </main>
 <footer class="site-footer">

--- a/public/ai/ai-development.html
+++ b/public/ai/ai-development.html
@@ -58,37 +58,49 @@
         </nav>
     </header>
     <main>
-        <h1>Transforming Ideas into Intelligent Solutions</h1>
-        <p>At Anvizor Solutions, we specialize in crafting bespoke AI solutions that drive innovation and efficiency. Our AI development services are designed to meet the unique needs of businesses across various industries, ensuring seamless integration and impactful results.</p>
+        <section class="hero">
+            <h1>Transforming Ideas into Intelligent Solutions</h1>
+        </section>
 
-        <h2>Our AI Development Services</h2>
-        <ul>
-            <li>Custom AI Solutions: Tailored AI applications that align with your business objectives.</li>
-            <li>Machine Learning Models: Developing predictive models to enhance decision-making processes.</li>
-            <li>Natural Language Processing (NLP): Enabling machines to understand and interpret human language effectively.</li>
-            <li>Computer Vision: Implementing image and video analysis for advanced visual recognition tasks.</li>
-            <li>AI Integration: Seamless incorporation of AI capabilities into existing systems and workflows.</li>
-        </ul>
+        <section class="section intro">
+            <p>At Anvizor Solutions, we specialize in crafting bespoke AI solutions that drive innovation and efficiency. Our AI development services are designed to meet the unique needs of businesses across various industries, ensuring seamless integration and impactful results.</p>
+        </section>
 
-        <h2>Industries We Serve</h2>
-        <ul>
-            <li>Healthcare: Enhancing patient care through predictive analytics and diagnostic tools.</li>
-            <li>Finance: Automating processes and improving risk assessment with intelligent algorithms.</li>
-            <li>Retail: Personalizing customer experiences and optimizing inventory management.</li>
-            <li>Manufacturing: Streamlining operations with predictive maintenance and quality control.</li>
-        </ul>
+        <section class="section services">
+            <h2>Our AI Development Services</h2>
+            <ul>
+                <li>Custom AI Solutions: Tailored AI applications that align with your business objectives.</li>
+                <li>Machine Learning Models: Developing predictive models to enhance decision-making processes.</li>
+                <li>Natural Language Processing (NLP): Enabling machines to understand and interpret human language effectively.</li>
+                <li>Computer Vision: Implementing image and video analysis for advanced visual recognition tasks.</li>
+                <li>AI Integration: Seamless incorporation of AI capabilities into existing systems and workflows.</li>
+            </ul>
+        </section>
 
-        <h2>Why Choose Anvizor Solutions?</h2>
-        <ul>
-            <li>Expertise: A team of seasoned professionals with deep knowledge in AI technologies.</li>
-            <li>Customized Approach: Solutions tailored to fit your specific business needs and challenges.</li>
-            <li>End-to-End Support: Comprehensive services from consultation to deployment and maintenance.</li>
-            <li>Ethical AI Practices: Commitment to responsible AI development, ensuring transparency and fairness.</li>
-        </ul>
+        <section class="section industries">
+            <h2>Industries We Serve</h2>
+            <ul>
+                <li>Healthcare: Enhancing patient care through predictive analytics and diagnostic tools.</li>
+                <li>Finance: Automating processes and improving risk assessment with intelligent algorithms.</li>
+                <li>Retail: Personalizing customer experiences and optimizing inventory management.</li>
+                <li>Manufacturing: Streamlining operations with predictive maintenance and quality control.</li>
+            </ul>
+        </section>
 
-        <h2>Get Started</h2>
-        <section class="call-to-action">
-            <p>Ready to harness the power of AI for your business? <a href="/contact-us.html">Contact Us</a> or <a href="/contact-us.html">Schedule a Consultation</a></p>
+        <section class="section why-choose">
+            <h2>Why Choose Anvizor Solutions?</h2>
+            <ul>
+                <li>Expertise: A team of seasoned professionals with deep knowledge in AI technologies.</li>
+                <li>Customized Approach: Solutions tailored to fit your specific business needs and challenges.</li>
+                <li>End-to-End Support: Comprehensive services from consultation to deployment and maintenance.</li>
+                <li>Ethical AI Practices: Commitment to responsible AI development, ensuring transparency and fairness.</li>
+            </ul>
+        </section>
+
+        <section class="section cta">
+            <h2>Get Started</h2>
+            <p>Ready to harness the power of AI for your business?</p>
+            <p class="cta-links"><a href="/contact-us.html">Contact Us</a> or <a href="/contact-us.html">Schedule a Consultation</a></p>
         </section>
     </main>
 <footer class="site-footer">

--- a/public/ai/generative-ai.html
+++ b/public/ai/generative-ai.html
@@ -58,41 +58,55 @@
         </nav>
     </header>
     <main>
-        <h1>Create. Innovate. Transform. With Generative AI</h1>
-        <p>Generative AI at Anvizor Solutions enables businesses to go beyond automation and embrace creativity. From text and image generation to advanced simulations and product design, we help you harness the power of AI to innovate faster and more efficiently.</p>
+        <section class="hero">
+            <h1>Create. Innovate. Transform. With Generative AI</h1>
+        </section>
 
-        <h2>What is Generative AI?</h2>
-        <p>Generative AI refers to algorithms that can generate new content—text, images, code, audio, and more—based on learned data patterns. It’s a leap forward from traditional AI by not just analyzing data, but creating entirely new outputs.</p>
+        <section class="section intro">
+            <p>Generative AI at Anvizor Solutions enables businesses to go beyond automation and embrace creativity. From text and image generation to advanced simulations and product design, we help you harness the power of AI to innovate faster and more efficiently.</p>
+        </section>
 
-        <h2>Our Generative AI Capabilities</h2>
-        <ul>
-            <li>Text Generation: Summarization, content creation, translations, chatbots</li>
-            <li>Image &amp; Video Generation: Visual content creation for marketing and design</li>
-            <li>Code Generation: Smart assistants that write and debug code</li>
-            <li>Data Augmentation: Synthesize training data for AI models</li>
-            <li>3D Modeling &amp; Design: Generate visual assets for gaming, AR/VR, and prototyping</li>
-        </ul>
+        <section class="section overview">
+            <h2>What is Generative AI?</h2>
+            <p>Generative AI refers to algorithms that can generate new content—text, images, code, audio, and more—based on learned data patterns. It’s a leap forward from traditional AI by not just analyzing data, but creating entirely new outputs.</p>
+        </section>
 
-        <h2>Industries We Empower</h2>
-        <ul>
-            <li>Marketing &amp; Advertising: Automated content and campaign generation</li>
-            <li>E-commerce: Personalized product visuals and descriptions</li>
-            <li>Healthcare: Synthetic medical data and diagnostics support</li>
-            <li>Finance: Report automation, document generation</li>
-            <li>Gaming &amp; Entertainment: 3D design, storyline creation, audio synthesis</li>
-        </ul>
+        <section class="section capabilities">
+            <h2>Our Generative AI Capabilities</h2>
+            <ul>
+                <li>Text Generation: Summarization, content creation, translations, chatbots</li>
+                <li>Image &amp; Video Generation: Visual content creation for marketing and design</li>
+                <li>Code Generation: Smart assistants that write and debug code</li>
+                <li>Data Augmentation: Synthesize training data for AI models</li>
+                <li>3D Modeling &amp; Design: Generate visual assets for gaming, AR/VR, and prototyping</li>
+            </ul>
+        </section>
 
-        <h2>Why Anvizor’s Generative AI?</h2>
-        <ul>
-            <li>Secure, Ethical, and Compliant AI Development</li>
-            <li>Fine-Tuned Models for Specific Business Needs</li>
-            <li>Scalable API Integration</li>
-            <li>Human-in-the-loop Validation</li>
-            <li>Custom Training on Proprietary Data</li>
-        </ul>
+        <section class="section industries">
+            <h2>Industries We Empower</h2>
+            <ul>
+                <li>Marketing &amp; Advertising: Automated content and campaign generation</li>
+                <li>E-commerce: Personalized product visuals and descriptions</li>
+                <li>Healthcare: Synthetic medical data and diagnostics support</li>
+                <li>Finance: Report automation, document generation</li>
+                <li>Gaming &amp; Entertainment: 3D design, storyline creation, audio synthesis</li>
+            </ul>
+        </section>
 
-        <section class="call-to-action">
-            <p>Let us help you redefine what’s possible. <a href="/contact-us.html">Talk to an AI Expert</a> or <a href="/contact-us.html">Book a Free Demo</a></p>
+        <section class="section why-choose">
+            <h2>Why Anvizor’s Generative AI?</h2>
+            <ul>
+                <li>Secure, Ethical, and Compliant AI Development</li>
+                <li>Fine-Tuned Models for Specific Business Needs</li>
+                <li>Scalable API Integration</li>
+                <li>Human-in-the-loop Validation</li>
+                <li>Custom Training on Proprietary Data</li>
+            </ul>
+        </section>
+
+        <section class="section cta">
+            <p>Let us help you redefine what’s possible.</p>
+            <p class="cta-links"><a href="/contact-us.html">Talk to an AI Expert</a> or <a href="/contact-us.html">Book a Free Demo</a></p>
         </section>
     </main>
 <footer class="site-footer">

--- a/public/ai/mlops.html
+++ b/public/ai/mlops.html
@@ -58,40 +58,54 @@
         </nav>
     </header>
     <main>
-        <h1>Streamline, Scale, and Secure Your Machine Learning Operations</h1>
-        <p>At Anvizor Solutions, we specialize in delivering end-to-end MLOps solutions that bridge the gap between data science and IT operations. Our services ensure that machine learning models are deployed quickly, scale efficiently, and deliver accurate predictions over time.</p>
+        <section class="hero">
+            <h1>Streamline, Scale, and Secure Your Machine Learning Operations</h1>
+        </section>
 
-        <h2>What is MLOps?</h2>
-        <p>MLOps, short for Machine Learning Operations, refers to the practice of combining machine learning system development and operations to automate and streamline the ML lifecycle. This includes everything from data collection and model training to deployment and monitoring.</p>
+        <section class="section intro">
+            <p>At Anvizor Solutions, we specialize in delivering end-to-end MLOps solutions that bridge the gap between data science and IT operations. Our services ensure that machine learning models are deployed quickly, scale efficiently, and deliver accurate predictions over time.</p>
+        </section>
 
-        <h2>Our MLOps Capabilities</h2>
-        <ul>
-            <li>Automated ML Pipelines: Streamline the process from data ingestion to model deployment.</li>
-            <li>Continuous Integration and Deployment (CI/CD): Implement robust CI/CD practices for ML models to ensure rapid and reliable updates.</li>
-            <li>Model Monitoring and Management: Continuously monitor model performance and manage model versions effectively.</li>
-            <li>Scalability: Deploy models that can scale seamlessly with your business needs.</li>
-            <li>Security and Compliance: Ensure that all ML operations adhere to industry standards and regulations.</li>
-        </ul>
+        <section class="section overview">
+            <h2>What is MLOps?</h2>
+            <p>MLOps, short for Machine Learning Operations, refers to the practice of combining machine learning system development and operations to automate and streamline the ML lifecycle. This includes everything from data collection and model training to deployment and monitoring.</p>
+        </section>
 
-        <h2>Industries We Serve</h2>
-        <ul>
-            <li>Healthcare: Enhancing diagnostic tools and patient care through reliable ML models.</li>
-            <li>Finance: Improving fraud detection and risk assessment with scalable ML solutions.</li>
-            <li>E-commerce: Personalizing customer experiences and optimizing supply chains.</li>
-            <li>Manufacturing: Predictive maintenance and quality control through advanced analytics.</li>
-        </ul>
+        <section class="section capabilities">
+            <h2>Our MLOps Capabilities</h2>
+            <ul>
+                <li>Automated ML Pipelines: Streamline the process from data ingestion to model deployment.</li>
+                <li>Continuous Integration and Deployment (CI/CD): Implement robust CI/CD practices for ML models to ensure rapid and reliable updates.</li>
+                <li>Model Monitoring and Management: Continuously monitor model performance and manage model versions effectively.</li>
+                <li>Scalability: Deploy models that can scale seamlessly with your business needs.</li>
+                <li>Security and Compliance: Ensure that all ML operations adhere to industry standards and regulations.</li>
+            </ul>
+        </section>
 
-        <h2>Why Choose an Anvizor for MLOps?</h2>
-        <ul>
-            <li>Expertise: A team of seasoned professionals with deep knowledge in ML and DevOps.</li>
-            <li>Customized Solutions: Tailored MLOps strategies that align with your business objectives.</li>
-            <li>Proven Track Record: Successful implementation of MLOps solutions across various industries.</li>
-            <li>Continuous Support: Ongoing support to adapt and evolve your ML operations as needed.</li>
-        </ul>
+        <section class="section industries">
+            <h2>Industries We Serve</h2>
+            <ul>
+                <li>Healthcare: Enhancing diagnostic tools and patient care through reliable ML models.</li>
+                <li>Finance: Improving fraud detection and risk assessment with scalable ML solutions.</li>
+                <li>E-commerce: Personalizing customer experiences and optimizing supply chains.</li>
+                <li>Manufacturing: Predictive maintenance and quality control through advanced analytics.</li>
+            </ul>
+        </section>
 
-        <h2>Get Started</h2>
-        <section class="call-to-action">
-            <p>Ready to optimize your machine learning operations? <a href="/contact-us.html">Contact Us</a> or <a href="/contact-us.html">Schedule a Consultation</a></p>
+        <section class="section why-choose">
+            <h2>Why Choose an Anvizor for MLOps?</h2>
+            <ul>
+                <li>Expertise: A team of seasoned professionals with deep knowledge in ML and DevOps.</li>
+                <li>Customized Solutions: Tailored MLOps strategies that align with your business objectives.</li>
+                <li>Proven Track Record: Successful implementation of MLOps solutions across various industries.</li>
+                <li>Continuous Support: Ongoing support to adapt and evolve your ML operations as needed.</li>
+            </ul>
+        </section>
+
+        <section class="section cta">
+            <h2>Get Started</h2>
+            <p>Ready to optimize your machine learning operations?</p>
+            <p class="cta-links"><a href="/contact-us.html">Contact Us</a> or <a href="/contact-us.html">Schedule a Consultation</a></p>
         </section>
     </main>
 <footer class="site-footer">


### PR DESCRIPTION
## Summary
- restructure AI product pages using `<section>` blocks
- add hero, intro, and CTA sections for consistency

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68529d107f748324b94d8ed565cf5500