### PR TITLE
Refresh theme colors and fonts

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,19 +1,33 @@
 /* Modern corporate theme */
 :root {
-    --accent-color: #0097a7;
-    --text-color: #333;
+    /* Updated palette inspired by droverseas.com */
+    --accent-color: #0057b7;
+    --text-color: #222;
     --bg-color: #ffffff;
-    --light-gray: #f5f5f5;
+    --light-gray: #f0f2f5;
 }
 
 body {
-    font-family: 'Poppins', 'Roboto', "Helvetica Neue", Arial, sans-serif;
+    font-family: 'Poppins', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+    font-size: 1rem;
     margin: 0;
     padding: 0;
     background-color: var(--bg-color);
     color: var(--text-color);
     line-height: 1.6;
 }
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Poppins', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+    margin-top: 0;
+}
+
+h1 { font-size: 2rem; }
+h2 { font-size: 1.5rem; }
+h3 { font-size: 1.25rem; }
+h4 { font-size: 1.1rem; }
+h5 { font-size: 1rem; }
+h6 { font-size: 0.875rem; }
 
 .navbar {
     background-color: #0d47a1;
@@ -101,7 +115,7 @@ body {
 .contact-section h2 {
     margin-bottom: 10px;
     color: var(--accent-color);
-    font-size: 1.1rem;
+    font-size: 1.25rem;
 }
 
 .contact-section label {
@@ -242,12 +256,13 @@ body {
 .hero h1 {
     margin: 0;
     color: #fff;
+    font-size: 2.5rem;
 }
 
 .hero p {
     max-width: 800px;
     margin: 20px auto;
-    font-size: 1.1rem;
+    font-size: 1.125rem;
     color: #f0f0f0;
 }
 


### PR DESCRIPTION
## Summary
- use blue palette and open-source font stack
- set base font-size and heading scale
- tweak contact and hero styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685304827dd883249649e3e0c922080c