### PR TITLE
Fix product-engineering layout

### DIFF
--- a/public/services/product-engineering.html
+++ b/public/services/product-engineering.html
@@ -58,35 +58,43 @@
         </nav>
     </header>
     <main>
-        <h1>From Idea to Impact — Scalable Product Engineering with Precision</h1>
-        <p>At Anvizor Solutions, we specialize in full-cycle product engineering — from concept validation to development, deployment, and beyond. We help businesses bring innovative ideas to life through scalable, secure, and future-ready digital products. Whether you're launching a new platform or modernizing a legacy solution, our team ensures gold-standard execution every step of the way.</p>
+        <section class="section hero">
+            <h1>From Idea to Impact — Scalable Product Engineering with Precision</h1>
+            <p>At Anvizor Solutions, we specialize in full-cycle product engineering — from concept validation to development, deployment, and beyond. We help businesses bring innovative ideas to life through scalable, secure, and future-ready digital products. Whether you're launching a new platform or modernizing a legacy solution, our team ensures gold-standard execution every step of the way.</p>
+        </section>
 
-        <h2>Our Product Engineering Capabilities</h2>
-        <ul>
-            <li>Product Development from Scratch: Transform your business vision into a market-ready digital product with our end-to-end engineering services.</li>
-            <li>Architecture &amp; Scalability Planning: Design robust, high-performing architectures built to scale with user growth and future innovation.</li>
-            <li>Agile Delivery Lifecycle: Delivering iterative releases with transparency, speed, and stakeholder collaboration.</li>
-            <li>Cutting-Edge Technology Stack: Leveraging the latest tech—cloud-native apps, microservices, and modern frontend-backend frameworks.</li>
-            <li>Post-Production Development: Continuous improvement and feature expansion to keep your product ahead of the curve.</li>
-        </ul>
+        <section class="section">
+            <h2>Our Product Engineering Capabilities</h2>
+            <ul>
+                <li>Product Development from Scratch: Transform your business vision into a market-ready digital product with our end-to-end engineering services.</li>
+                <li>Architecture &amp; Scalability Planning: Design robust, high-performing architectures built to scale with user growth and future innovation.</li>
+                <li>Agile Delivery Lifecycle: Delivering iterative releases with transparency, speed, and stakeholder collaboration.</li>
+                <li>Cutting-Edge Technology Stack: Leveraging the latest tech—cloud-native apps, microservices, and modern frontend-backend frameworks.</li>
+                <li>Post-Production Development: Continuous improvement and feature expansion to keep your product ahead of the curve.</li>
+            </ul>
+        </section>
 
-        <h2>Built-In Engineering Practices</h2>
-        <ul>
-            <li>User Acceptance Testing (UAT): Validate features with real-world users before go-live.</li>
-            <li>Hypercare Support: Providing critical support immediately after launch to ensure a seamless transition.</li>
-            <li>Continuous Integration &amp; Delivery (CI/CD): Automated pipelines for faster, reliable code deployment.</li>
-            <li>Quality-First Development: We integrate testing and code reviews at every phase for production-grade quality.</li>
-        </ul>
+        <section class="section">
+            <h2>Built-In Engineering Practices</h2>
+            <ul>
+                <li>User Acceptance Testing (UAT): Validate features with real-world users before go-live.</li>
+                <li>Hypercare Support: Providing critical support immediately after launch to ensure a seamless transition.</li>
+                <li>Continuous Integration &amp; Delivery (CI/CD): Automated pipelines for faster, reliable code deployment.</li>
+                <li>Quality-First Development: We integrate testing and code reviews at every phase for production-grade quality.</li>
+            </ul>
+        </section>
 
-        <h2>Why Choose Anvizor for Product Engineering?</h2>
-        <ul>
-            <li>Industry Gold Standards: Best practices and proven patterns applied across the product lifecycle.</li>
-            <li>From MVP to Scale: We support everything from rapid MVP development to large-scale enterprise rollouts.</li>
-            <li>Cross-Functional Teams: Integrated teams of product managers, architects, developers, and QA.</li>
-            <li>Long-Term Partnership: We evolve with your product—from launch to hypergrowth and beyond.</li>
-        </ul>
+        <section class="section">
+            <h2>Why Choose Anvizor for Product Engineering?</h2>
+            <ul>
+                <li>Industry Gold Standards: Best practices and proven patterns applied across the product lifecycle.</li>
+                <li>From MVP to Scale: We support everything from rapid MVP development to large-scale enterprise rollouts.</li>
+                <li>Cross-Functional Teams: Integrated teams of product managers, architects, developers, and QA.</li>
+                <li>Long-Term Partnership: We evolve with your product—from launch to hypergrowth and beyond.</li>
+            </ul>
+        </section>
 
-        <section class="call-to-action">
+        <section class="section call-to-action">
             <p>Let’s engineer a solution that stands out, scales, and succeeds. <a href="/contact-us.html">Contact Us</a> or <a href="/contact-us.html">Book a Product Strategy Call</a>.</p>
         </section>
     </main>


### PR DESCRIPTION
## Summary
- restructure `product-engineering.html` so it uses the same section layout as other service pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853dac789b48324821311ce3074c36c