### PR TITLE
Add images to AI Agent page

### DIFF
--- a/public/ai/ai-agent.html
+++ b/public/ai/ai-agent.html
@@ -58,20 +58,26 @@
         </nav>
     </header>
     <main>
-        <section class="hero">
-            <h1>Intelligent AI Agents That Think, Act, and Learn</h1>
+        <section class="hero with-image">
+            <img src="https://images.unsplash.com/photo-1581091012184-b6c0c43b0efb?auto=format&fit=crop&w=1200&q=80" alt="Illustration of artificial intelligence" />
+            <div class="hero-text">
+                <h1>Intelligent AI Agents That Think, Act, and Learn</h1>
+            </div>
         </section>
 
         <section class="section intro">
+            <img src="https://images.unsplash.com/photo-1534751516642-a1af1ef02611?auto=format&fit=crop&w=1200&q=80" alt="AI data visualization" />
             <p>Anvizor develops AI agents that autonomously analyze information, take action, and improve through continuous learning. Our technology transforms how businesses operate by automating complex tasks and delivering real-time insights.</p>
         </section>
 
         <section class="section overview">
+            <img src="https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1200&q=80" alt="Robot analyzing data" />
             <h2>What is an AI Agent?</h2>
             <p>An AI agent is a software program capable of perceiving its environment, reasoning about data, and performing tasks with minimal human input. These agents use machine learning to adapt and get better over time.</p>
         </section>
 
         <section class="section capabilities">
+            <img src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80" alt="Abstract AI interface" />
             <h2>Capabilities of Our AI Agents</h2>
             <ul>
                 <li>Natural language understanding</li>
@@ -82,6 +88,7 @@
         </section>
 
         <section class="section use-cases">
+            <img src="https://images.unsplash.com/photo-1527689368864-3a821dbccc34?auto=format&fit=crop&w=1200&q=80" alt="People interacting with AI" />
             <h2>Use Cases</h2>
             <ul>
                 <li>Customer support chatbots</li>
@@ -92,6 +99,7 @@
         </section>
 
         <section class="section why-choose">
+            <img src="https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=1200&q=80" alt="AI team discussion" />
             <h2>Why Choose Anvizor AI Agents?</h2>
             <ul>
                 <li>Proven expertise in artificial intelligence</li>
@@ -102,6 +110,7 @@
         </section>
 
         <section class="section cta">
+            <img src="https://images.unsplash.com/photo-1588422333073-2de6318a0428?auto=format&fit=crop&w=1200&q=80" alt="Handshake" />
             <p class="cta-links"><a href="/contact-us.html">Schedule a Call</a> or <a href="/contact-us.html">Request a Demo</a></p>
         </section>
     </main>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -281,6 +281,28 @@ h6 { font-size: 0.875rem; }
     color: #fff;
 }
 
+.hero.with-image {
+    background: none;
+    padding: 0;
+    position: relative;
+    text-align: center;
+}
+
+.hero.with-image img {
+    width: 100%;
+    height: 350px;
+    object-fit: cover;
+}
+
+.hero.with-image .hero-text {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: #fff;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+}
+
 .hero h1 {
     margin: 0;
     color: #fff;
@@ -317,6 +339,13 @@ p {
 
 .section ul li {
     margin-bottom: 10px;
+}
+
+.section img {
+    width: 100%;
+    height: auto;
+    margin-bottom: 20px;
+    border-radius: 6px;
 }
 
 .cta-links a {


### PR DESCRIPTION
## Summary
- create a new hero layout that supports a full-width image and overlay text
- style section images for consistent sizing
- add hero image and images to each section on the AI Agent page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853dee6d5248324b09cc8fa34492825