### PR TITLE
Refactor AI agent sections with two-column layout

### DIFF
--- a/public/ai/ai-agent.html
+++ b/public/ai/ai-agent.html
@@ -66,52 +66,76 @@
         </section>
 
         <section class="section intro">
-            <img src="https://images.unsplash.com/photo-1542831371-29b0f74f9713?auto=format&fit=crop&w=1200&q=80" alt="AI data visualization" />
-            <p>Anvizor develops AI agents that autonomously analyze information, take action, and improve through continuous learning. Our technology transforms how businesses operate by automating complex tasks and delivering real-time insights.</p>
+            <div class="two-column">
+                <img src="https://images.unsplash.com/photo-1542831371-29b0f74f9713?auto=format&fit=crop&w=1200&q=80" alt="AI data visualization" />
+                <div>
+                    <p>Anvizor develops AI agents that autonomously analyze information, take action, and improve through continuous learning. Our technology transforms how businesses operate by automating complex tasks and delivering real-time insights.</p>
+                </div>
+            </div>
         </section>
 
         <section class="section overview">
-            <img src="https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1200&q=80" alt="Robot analyzing data" />
-            <h2>What is an AI Agent?</h2>
-            <p>An AI agent is a software program capable of perceiving its environment, reasoning about data, and performing tasks with minimal human input. These agents use machine learning to adapt and get better over time.</p>
+            <div class="two-column">
+                <img src="https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1200&q=80" alt="Robot analyzing data" />
+                <div>
+                    <h2>What is an AI Agent?</h2>
+                    <p>An AI agent is a software program capable of perceiving its environment, reasoning about data, and performing tasks with minimal human input. These agents use machine learning to adapt and get better over time.</p>
+                </div>
+            </div>
         </section>
 
         <section class="section capabilities">
-            <img src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80" alt="Abstract AI interface" />
-            <h2>Capabilities of Our AI Agents</h2>
-            <ul>
-                <li>Natural language understanding</li>
-                <li>Decision making with predictive analytics</li>
-                <li>Process automation and workflow orchestration</li>
-                <li>Integration with existing business systems</li>
-            </ul>
+            <div class="two-column">
+                <img src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80" alt="Abstract AI interface" />
+                <div>
+                    <h2>Capabilities of Our AI Agents</h2>
+                    <ul>
+                        <li>Natural language understanding</li>
+                        <li>Decision making with predictive analytics</li>
+                        <li>Process automation and workflow orchestration</li>
+                        <li>Integration with existing business systems</li>
+                    </ul>
+                </div>
+            </div>
         </section>
 
         <section class="section use-cases">
-            <img src="https://images.unsplash.com/photo-1527689368864-3a821dbccc34?auto=format&fit=crop&w=1200&q=80" alt="People interacting with AI" />
-            <h2>Use Cases</h2>
-            <ul>
-                <li>Customer support chatbots</li>
-                <li>Automated financial analysis</li>
-                <li>Smart logistics and supply chain management</li>
-                <li>Personalized marketing recommendations</li>
-            </ul>
+            <div class="two-column">
+                <img src="https://images.unsplash.com/photo-1527689368864-3a821dbccc34?auto=format&fit=crop&w=1200&q=80" alt="People interacting with AI" />
+                <div>
+                    <h2>Use Cases</h2>
+                    <ul>
+                        <li>Customer support chatbots</li>
+                        <li>Automated financial analysis</li>
+                        <li>Smart logistics and supply chain management</li>
+                        <li>Personalized marketing recommendations</li>
+                    </ul>
+                </div>
+            </div>
         </section>
 
         <section class="section why-choose">
-            <img src="https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=1200&q=80" alt="AI team discussion" />
-            <h2>Why Choose Anvizor AI Agents?</h2>
-            <ul>
-                <li>Proven expertise in artificial intelligence</li>
-                <li>Custom solutions tailored to your industry</li>
-                <li>Scalable architecture for enterprise needs</li>
-                <li>Dedicated support and ongoing optimization</li>
-            </ul>
+            <div class="two-column">
+                <img src="https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=1200&q=80" alt="AI team discussion" />
+                <div>
+                    <h2>Why Choose Anvizor AI Agents?</h2>
+                    <ul>
+                        <li>Proven expertise in artificial intelligence</li>
+                        <li>Custom solutions tailored to your industry</li>
+                        <li>Scalable architecture for enterprise needs</li>
+                        <li>Dedicated support and ongoing optimization</li>
+                    </ul>
+                </div>
+            </div>
         </section>
 
         <section class="section cta">
-            <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80" alt="Handshake" />
-            <p class="cta-links"><a href="/contact-us.html">Schedule a Call</a> or <a href="/contact-us.html">Request a Demo</a></p>
+            <div class="two-column">
+                <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80" alt="Handshake" />
+                <div>
+                    <p class="cta-links"><a href="/contact-us.html">Schedule a Call</a> or <a href="/contact-us.html">Request a Demo</a></p>
+                </div>
+            </div>
         </section>
     </main>
 <footer class="site-footer">

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -386,3 +386,33 @@ p {
         cursor: pointer;
     }
 }
+
+/* Reusable two-column layout */
+.two-column {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 20px;
+}
+
+.two-column > img {
+    flex: 1 1 40%;
+    max-width: 45%;
+    height: auto;
+    border-radius: 6px;
+}
+
+.two-column > div {
+    flex: 1 1 55%;
+}
+
+@media (max-width: 768px) {
+    .two-column {
+        flex-direction: column;
+    }
+    .two-column > img,
+    .two-column > div {
+        max-width: 100%;
+        flex-basis: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- wrap AI agent sections after hero in a new `.two-column` layout
- add reusable `.two-column` styles and responsive image sizing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853e5a432008324ba77026a65244bfa